### PR TITLE
Add theme switcher to toggle between light and dark themes

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,22 @@
 import type { AppProps } from 'next/app';
+import { useState, useEffect } from 'react';
 import '../styles/globals.css';
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('theme');
+    const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    setTheme(savedTheme || systemTheme);
+  }, []);
+
+  useEffect(() => {
+    document.body.className = theme;
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  return <Component {...pageProps} theme={theme} setTheme={setTheme} />;
 }
 
 export default MyApp;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styles from '../styles/Home.module.css';
 
-const Home: React.FC = () => {
+const Home: React.FC<{ theme: string, setTheme: (theme: string) => void }> = ({ theme, setTheme }) => {
   const [username, setUsername] = useState('');
   const [profile, setProfile] = useState<any>(null);
-
   const [errorMessage, setErrorMessage] = useState('');
 
   const handleSearch = async () => {
@@ -34,8 +33,12 @@ const Home: React.FC = () => {
     }
   };
 
+  const toggleTheme = () => {
+    setTheme(theme === 'light' ? 'dark' : 'light');
+  };
+
   return (
-    <div className={styles.container}>
+    <div className={`${styles.container} ${theme === 'dark' ? styles.dark : ''}`}>
       <h1 className={styles.title}>GitHub Profile Search</h1>
       <p className={styles.description}>
       Search for a GitHub user profile by entering their username in the search box below.
@@ -51,6 +54,9 @@ const Home: React.FC = () => {
         />
         <button onClick={handleSearch} className={styles.button}>Search</button>
       </div>
+      <button onClick={toggleTheme} className={styles.button}>
+        Switch to {theme === 'light' ? 'Dark' : 'Light'} Theme
+      </button>
       {errorMessage && <p className={styles.error}>{errorMessage}</p>}
       {profile && (
       <div className={styles.profile}>

--- a/styles/Home.module.css
+++ b/styles/Home.module.css
@@ -55,3 +55,28 @@
 .link {
   text-decoration: underline;
 }
+
+/* Dark theme styles */
+.home.dark {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
+.title.dark {
+  color: #bb86fc;
+}
+
+.description.dark {
+  color: #e0e0e0;
+}
+
+.input.dark {
+  background-color: #333;
+  color: #e0e0e0;
+  border: 1px solid #444;
+}
+
+.button.dark {
+  background-color: #444;
+  color: #e0e0e0;
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -26,3 +26,26 @@ ul {
 button {
   cursor: pointer;
 }
+
+/* Dark theme styles */
+body.dark {
+  background-color: #121212;
+  color: #e0e0e0;
+}
+
+a.dark {
+  color: #bb86fc;
+}
+
+h1.dark, h2.dark, h3.dark, h4.dark, h5.dark, h6.dark {
+  color: #e0e0e0;
+}
+
+ul.dark {
+  color: #e0e0e0;
+}
+
+button.dark {
+  background-color: #333;
+  color: #e0e0e0;
+}


### PR DESCRIPTION
Add theme switcher functionality to toggle between light and dark themes.

* **styles/globals.css**
  - Add dark theme styles for `body`, `a`, `h1, h2, h3, h4, h5, h6`, `ul`, and `button`.

* **styles/Home.module.css**
  - Add dark theme styles for `.home`, `.title`, `.description`, `.input`, and `.button`.

* **pages/_app.tsx**
  - Add theme-related state to manage the current theme.
  - Add logic to apply the current theme to the `body` element.
  - Add logic to persist the current theme in local storage.

* **pages/index.tsx**
  - Add theme switcher UI component to allow users to switch themes.
  - Add logic to toggle between light and dark themes.
  - Add logic to use the system theme as default.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/aatmmr/github-profile-search/pull/3?shareId=66f8fdeb-912f-437e-a487-70ddbd9508ba).